### PR TITLE
feat: debloat package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,8 +39,7 @@
   "dependencies": {
     "mkdirp": "^0.5.1",
     "underscore.string": "^3.0.3",
-    "yeoman-generator": "^0.20.1",
-    "gulp-babel": "^6.1.2"
+    "yeoman-generator": "^0.20.1"
   },
   "devDependencies": {
     "babel-cli": "^6.6.5",


### PR DESCRIPTION
Hi,

Thanks for developing this good project, which provides high-coverage tests.

I'm doing dynamic analysis on npm packages, and your project is one of my samples.

Through our dynamic analysis by running the test suites, we find that one of the runtime dependencies is installed, however, it is not used during test runtime. We removed this dependency from package.json, and installed the remaining dependencies, the tests all passed.

Would you consider creating a slim version of the package.json, which can help reduce the corresponding maintenance costs and security risks in production?
